### PR TITLE
タスクを削除できるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,7 +16,7 @@ class TasksController < ApplicationController
       flash[:notice] = 'Task created successfully'
       redirect_to tasks_path
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -28,7 +28,7 @@ class TasksController < ApplicationController
       flash[:notice] = 'Task updated successfully'
       redirect_to tasks_path
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: %i[edit update]
+  before_action :set_task, only: %i[edit update destroy]
 
   def index
     @tasks = Task.all
@@ -30,6 +30,13 @@ class TasksController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @task.destroy
+
+    flash[:notice] = 'Task deleted successfully'
+    redirect_to tasks_path
   end
 
   private

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
-
-Turbo.session.drive = false

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,7 +3,10 @@
 <div>
   <ul>
     <% @tasks.each do |task| %>
-      <li><%= task.name %></li>
+      <li>
+        <%= task.name %>
+        <%= link_to "🗑️", task, method: :delete, data: { confirm: "『#{task.name}』のタスクを削除します。よろしいですか？"} %>
+      </li>
     <% end %>
   </ul>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,7 +5,7 @@
     <% @tasks.each do |task| %>
       <li>
         <%= task.name %>
-        <%= link_to "🗑️", task, method: :delete, data: { confirm: "『#{task.name}』のタスクを削除します。よろしいですか？"} %>
+        <%= link_to "🗑️", task, data: { turbo_method: :delete, turbo_confirm: "タスク『#{task.name}』を削除します。よろしいですか？"} %>
       </li>
     <% end %>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root to: "tasks#index"
-  resources :tasks, only: %i[index new create edit update]
+  resources :tasks, only: %i[index new create edit update destroy]
 end


### PR DESCRIPTION
#7

#### アプリケーション全体でTurboを無効にしないようにした
- rails7ではrails-usjが標準構成から外れてturboが標準構成になっている。
- deleteメソッドはlink_toのURLヘルパーで生成された場合、jsがgetメソッドからdeleteメソッドに変換しているらしい
- turboでjsを動かす必要があるので無効にしないことにする

#### タスクが保存できなかったときに422を返すようにした
- turboではrenderで適切なステータスコードを選択しない場合にページの再描画が行われないらしい。
- その結果バリデーションエラーメッセージが表示できないので、422を返す