### PR TITLE
Userモデルを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "stimulus-rails"
 gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
+gem "bcrypt", '~> 3.1.13'
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -214,6 +215,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  bcrypt (~> 3.1.13)
   bootsnap
   debug
   factory_bot_rails (~> 6.4.3)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+
+  has_secure_password
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { 'テスト太郎' }
+    sequence(:email) { |n| "sample#{n}@example.com" }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe User do
+  describe 'valid?' do
+    describe 'name' do
+      let(:user) { build(:user, name: name) }
+
+      subject { user.valid? }
+
+      context 'nilのとき' do
+        let(:name) { nil }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe 'email' do
+      let(:user) { build(:user, email: email) }
+
+      subject { user.valid? }
+
+      context 'nilのとき' do
+        let(:email) { nil }
+
+        it { is_expected.to be false }
+      end
+
+      context '既に同じemailを持つユーザーが存在するとき' do
+        before { create(:user, email: email) }
+        let(:email) { 'sample@example.com' }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#9 

```sh
$ rspec spec               
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      diff-lcs (>= 1.2.0, < 2.0)
      Available/installed versions of this gem:
      - 1.5.1
      - 1.5.0
      - 1.4.4
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
/Users/handaryuu/.rbenv/versions/3.0.1/lib/ruby/3.0.0/x86_64-darwin19/strscan.bundle: warning: already initialized constant StringScanner::Version
/Users/handaryuu/.rbenv/versions/3.0.1/lib/ruby/3.0.0/x86_64-darwin19/strscan.bundle: warning: already initialized constant StringScanner::Id
...

Finished in 0.05331 seconds (files took 2.08 seconds to load)
3 examples, 0 failures
```