### PR TITLE
既存のタスクとユーザーを関連づけるバッチ処理

### DIFF
--- a/lib/tasks/insert_user_id_to_tasks.rake
+++ b/lib/tasks/insert_user_id_to_tasks.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :user_id do
+  desc "タスクにユーザーIDを挿入する"
+
+  task insert_to_tasks: :environment do
+    updated_tasks = []
+    faild_tasks = []
+
+    Task.where(user_id: nil).find_each do |task|
+      user = User.first
+
+      if task.update(user_id: user.id)
+        updated_tasks << task.id
+      else
+        faild_tasks << task.id
+      end
+    end
+
+    puts "success tasks: #{updated_tasks.join(', ')}"
+    puts "=" * 20
+    puts "faild tasks: #{faild_tasks.join(', ')}"
+  end
+end

--- a/spec/lib/tasks/insert_user_id_to_tasks_spec.rb
+++ b/spec/lib/tasks/insert_user_id_to_tasks_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "rake_helper"
+
+describe "insert_user_id_to_tasks", type: :task do
+  describe "user_id:insert_to_tasks" do
+    let(:task) { Rake.application["user_id:insert_to_tasks"] }
+
+    before do
+      create(:user)
+
+      5.times do |i|
+        Task.create(name: "task#{i}", user_id: nil)
+      end
+    end
+
+    it "全てのタスクにユーザーが関連づけられる" do
+      expect { task.invoke }.to change { Task.where(user_id: nil).count }.from(5).to(0)
+    end
+  end
+end

--- a/spec/rake_helper.rb
+++ b/spec/rake_helper.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    # 全てのrakeタスクを読み込む
+    Rails.application.load_tasks
+  end
+
+  config.before(:each) do
+    # example間での永続性を取り除く
+    Rake.application.tasks.each(&:reenable)
+  end
+end


### PR DESCRIPTION
#9 
本来はバッチ処理中にも新規にタスクが作成されることを考慮して
- `before_validation`などで新規に作られるタスクにはユーザーが関連づけられるようにする
- バッチで既存のタスクとユーザーを関連づける

という手順を踏むことで全てのタスクとユーザーが関連づけられることを担保したいが、今回は自分しか操作しないことと上記手順に思いを馳せていること自体が大切ということにしてバッチだけで済ませる。